### PR TITLE
First draft of section IV.16.5

### DIFF
--- a/ega4/ega4-16.tex
+++ b/ega4/ega4-16.tex
@@ -1200,3 +1200,115 @@ We immediately generalize \sref{IV.16.4.23} to the case of a product of any fini
 \end{enumerate}
 \end{remarks}
 
+\subsection{Relative tangent sheaves and bundles; derivations.}
+\label{IV.16.5}
+
+\begin{env}[16.5.1]
+\label{IV.16.5.1}
+Let $f = (\psi, \theta):X \to S$ be a morphism of ringed spaces.
+For every $\sh{O}_X$-module $\sh{F}$, we call $S$-\emph{derivation} (or $(X/S)$-derivation, or $f$-derivation) of $\sh{O}_X$ to $\sh{F}$ every homomorphism of \emph{sheaves of additive groups} $D: \sh{O}_X \to \sh{F}$, verifying the following conditions:
+\begin{enumerate}
+  \item[\rm{(a)}] for every open set $V$ of $X$, and all pair of sections $(t_1, t_2)$ of $\sh{O}_X$ over $V$, we have
+  \[
+    \label{IV.16.5.1.1}
+    D(t_1t_2) = t_1D(t_2) + D(t_1)t_2;
+    \tag{16.5.1.1}
+  \]
+  \item[\rm{(b)}] for every open set $V$ of $X$, every section $t$ of $\sh{O}_X$ over $V$ and every section $s$ of $\sh{O}_S$ over an open set $U$ of $S$ such that $V \subset f^{-1}(U)$, we have
+  \[
+    \label{IV.16.5.1.2}
+    D((s|V)t) = (s|V)D(t).
+    \tag{16.5.1.2}
+  \]
+\end{enumerate}
+It is clear that this amounts to saying that, for all $x \in X$, the homomorphism of additive groups $D_x:\sh{O}_x \to \sh{F}_x$ is an $\sh{O}_{f(x)}$-derivation.
+
+Another interpretation consists in considering the $\sh{O}_X$-algebra $\sh{D}_{\sh{O}_X}(\sh{F})$ equal to $\sh{O}_X \oplus \sh{F}$, the algebra structure being defined by the condition that for every open set $V$ of $X$, the product of two sections of $\sh{O}_X$ (resp. of a section of $\sh{O}_X$ and a section of $\sh{F}$) over $V$ is defined by the ring structure of $\Gamma(V, \sh{O}_X)$ (resp. the $\Gamma(V, \sh{O}_X)$-module structure on $\Gamma(V, \sh{F})$), and the product of two sections of $\sh{F}$ over $V$ is chosen to be zero;
+then $\sh{F}$ is an ideal of $\sh{D}_{\sh{O}_X}(\sh{F})$, kernel of the canonical augmentation $\sh{D}_{\sh{O}_X}(\sh{F}) \to \sh{O}_X$, and to say that $D$ is an $S$-derivation of $\sh{O}_X$ in $\sh{F}$ means that $1_{\sh{O}_X} + D$ is an $\sh{O}_S$-homomorphism of algebras from $\sh{O}_X$ into $\sh{D}_{\sh{O}_X}(\sh{F})$, which, composed with the augmentation, gives $1_{\sh{O}_X}$.
+
+The $S$-derivations of $\sh{O}_X$ in $\sh{F}$ clearly form a $\Gamma(X, \sh{O}_X)$-module $\Der_{\sh{O}_S}(\sh{O}_X, \sh{F})$.
+
+When $\sh{F} = \sh{O}_X$, an $S$-derivation of $\sh{O}_X$ to itself is simply called an $S$-derivation of $\sh{O}_X$.
+\end{env}
+
+\begin{proposition}[16.5.2]
+\label{IV.16.5.2}
+Let $A$ be a ring, $B$ an $A$-algebra, $L$ a $B$-module;
+let $S = \Spec(A)$, $X=\Spec(B)$, $\sh{F} = \widetilde{L}$.
+Then the mapping $D \mapsto \Gamma(D)$ which, to every $S$-derivation $D$ of $\sh{O}_X$ to $\sh{F}$ gives us the mapping $\Gamma(D): t \mapsto D(t)$ of $B$ to $L$, is an isomorphism of $B$-modules of $\Der_S(\sh{O}_X, \sh{F})$ onto $\Der_A(B, L)$ (cf. \sref[0]{0.20.1.2}).
+\end{proposition}
+
+\begin{proof}
+This results immediately from the given interpretation of $S$-derivations in terms
+\oldpage[IV-4]{28}
+of homomorphisms of algebras, analogous to the interpretation given in \sref[0]{0.20.1.6}, and of the canonical correspondence between homomorphisms of $\sh{O}_X$-algebras and homomorphisms of $B$-algebras ( \sref[I]{I.1.3.13} and  \sref[I]{I.1.3.8}).
+\end{proof}
+
+\begin{proposition}[16.5.3]
+\label{IV.16.5.3}
+Let $f = (\psi, \theta): X \to S$ be a morphism of preschemes.
+\begin{enumerate}
+  \item[\rm{(i)}] The differential $d_{X/S}:\sh{O}_X \to \Omega_{X/S}^1$ \sref{IV.16.3.6} is an $S$-derivation.
+  \item[\rm{(ii)}] For every $\sh{O}_X$-module $\sh{F}$, the mapping $u \mapsto u \circ d_{X/S}$ is an isomorphism of $\Gamma(X, \sh{O}_X)$-modules
+  \[
+    \label{IV.16.5.3.1}
+    \Hom_{\sh{O}_X}(\Omega_{X/S}^1, \sh{F}) \xrightarrow\sim \Der_S(\sh{O}_X, \sh{F}).
+    \tag{16.5.3.1}
+  \]
+\end{enumerate}
+\end{proposition}
+
+\begin{proof}
+The assertion \rm{(i)} has already been noted \sref{IV.16.3.6}.
+On the other hand, it is immediate (in light of \sref[0]{0.20.4.8}) that $u \mapsto u\circ d_{X/S}$ is injective, considering considering the restrictions to a fiber $\sh{O}_x$ of the two members and \sref{IV.16.4.16.2}.
+To see that the homomorphism \sref{IV.16.5.3.1} is surjective, consider an $S$-derivation $D: \sh{O}_X \to \sh{F}$;
+for every affine open $V = \Spec(B) $ of $X$, such that $f(V)$ is contained in  an affine open $U = \Spec (A)$ of $S$, $D_V:B \to \Gamma(V, \sh{F}) $ is an $A$-derivation, and therefore there exists a \emph{unique} $B$-homomorphism $u_V:\Omega_{B/A}^1 \to \Gamma(V, \sh{F})$ such that $D_V = u_V \circ d_{B/A}$ \sref[0]{0.20.4.8};
+also, the uniqueness of the $u_V$ shows immediately that for an affine open $W \subset V$ we have $u_W = u_V|W$, and therefore the $u_V$ define a homomorphism of $\sh{O}_X$-modules $u:\sh{O}_X \to \sh{F}$ answering the question.
+\end{proof}
+
+\begin{env}[16.5.4]
+\label{IV.16.5.4}
+With the notations of \sref{IV.16.5.1}, for every open set $U$ of $X$, $\Der_S(\sh{O}_U, \sh{F}|U)$ is a $\Gamma(U, \sh{O}_X)$-module and it is cleat that the application $U \mapsto \Der_S(\sh{O}_U, \sh{F}|U)$ is a presheaf;
+in fact, it is even a \emph{sheaf} (and therefore an $\sh{O}_X$-module), in light of the pointwise characterization of $S$-derivations, seen in \sref{IV.16.5.1}.
+This $\sh{O}_X$-module is denoted by $\shDer_S(\sh{O}_X, \sh{F})$ and is called the \emph{sheaf of $S$-derivations of $\sh{O}_X$ in $\sh{F}$}, and what we've come to see is further expressed in the following corollary:
+\end{env}
+
+\begin{corollary}[16.5.5]
+\label{IV.16.5.5}
+For every $\sh{O}_X$-module $\sh{F}$, the homomorphism of $\sh{O}_X$-modules deduced from $d\mapsto u \circ d_{X/S}$
+\[
+  \label{IV.16.5.5.1}
+  \shHom_{\sh{O}_X}(\Omega_{X/S}^1, \sh{F}) \to \shDer_S(\sh{O}_X, \sh{F})
+  \tag{16.5.5.1}
+\]
+is bijective.
+\end{corollary}
+
+
+\begin{corollary}[16.5.6]
+\label{IV.16.5.6}
+\begin{enumerate}
+  \item[(i)] If the morphism $f:X \to S$ is locally of finite presentation and if $\sh{F}$ is a quasi-coherent $\sh{O}_X$-module, then $\shDer_S(\sh{O}_X, \sh{F})$ is a quasi-coherent $\sh{O}_X$-module.
+  \item[(ii)] If $S$ is also locally Noetherian and if $\sh{F}$ is quasi-coherent, then $\shDer_S(\sh{O}_X, \sh{F})$ is a coherent $\sh{O}_X$-module.
+\end{enumerate}
+\end{corollary}
+
+\begin{proof}
+The assertion (i) follows from the isomorphism \sref{IV.16.5.5.1}, from \sref{IV.16.4.22} and \sref[I]{I.3.12};
+the assertion (ii) follows from \sref[0]{0.5.3.5}.
+\end{proof}
+
+\begin{env}[16.5.7]
+\label{IV.16.5.7}
+We put
+\[
+  \label{IV.16.5.7.1}
+  \mathfrak{G}_{X/S} = \shHom_{\sh{O}_X}(\Omega_{X/S}^1, \sh{O}_X) = \shDer_S(\sh{O}_X, \sh{O}_X)
+  \tag{16.5.7.1}  
+\]
+and say that it is the \emph{sheaf of $S$-derivations of $\sh{O}_X$}, or even the \emph{tangent sheaf of $X$ relative to $S$}:
+it is therefore the dual of the $\sh{O}_X$-module $\Omega_{X/S}^1$.
+If $f$ is locally of finite
+\oldpage[IV-4]{29}
+presentation, $\mathfrak{G}_{X/S}$ is a quasi-coherent $\sh{O}_X$-module; if also $S$ is locally Noetherian, $\mathfrak{G}_{X/S}$ is coherent \sref{IV.16.5.6}.
+\end{env}

--- a/ega4/ega4-16.tex
+++ b/ega4/ega4-16.tex
@@ -1551,4 +1551,37 @@ also, if we replace $(\gamma_{\lambda\mu})$ by an $1$-cocycle $\gamma'_{\lambda\
 
 In particular,if $(\gamma_{\lambda\mu})$ is a $1$-coboundary, in other words of the form $\gamma_{\lambda\mu} = \beta_\lambda\beta_\mu^{-1}$, the obtained torsor $\sh{P}$ is \emph{isomorphic} to $\sh{G}$ (considered as a torsor over itself by left translations);
 we say in this case that $\sh{P}$ is trivial, and the converse is obvious.
+
+In particular, it results from \sref[III]{III.1.3.1} that:
 \end{env}
+
+\begin{proposition}[16.5.16]
+\label{IV.16.5.16}
+Let $Z$ be an affine scheme and $\sh{G}$ a quasi-coherent $\sh{O}_Z$-module;
+then every torsor over $\sh{G}$ is trivial.
+\end{proposition}
+
+\oldpage[IV-4]{34}
+
+Returnning to the problem considered in \sref{IV.16.5.13}, we obtain:
+
+\begin{proposition}[16.5.17]
+\label{IV.16.5.17}
+Let $X$, $Y$ be two $S$-preschemes, $Y_0$ a closed subprescheme of $Y$ defined by a quasi-coherent ideal $\sh{I}$ of $\sh{O}_Y$ such that $\sh{I}^2 = 0$, $j:Y_0 \to Y$ is the canonical injection.
+Let $u_0:Y_0 \to X$ be an $S$-morphism, and $\sh{P}$ the sheaf of sets on $Y$ such that, for every open set $U$ of $Y$, $\Gamma(U, \sh{P})$ is the set of $S$-morphisms $u:X \to X$ such that $u_0|U_0 = u \circ (j|U_0)$, where $U_0 = j^{-1}(U)$.
+Then it exists on $\sh{P}$ a structure of pseudo-torsor over the $\sh{O}_{Y_0}$-module $\sh{G} = \shHom_{\sh{O}_{Y_0}}(u_0^*(\Omega_{X/S}^1), \sh{I})$.
+\end{proposition}
+
+In particular:
+
+\begin{corollary}[16.5.18]
+\label{IV.16.5.18}
+Under the notations of \sref{IV.16.5.16}, suppose that $Y$ is affine and $\Omega_{X/S}^1$ is of finite presentation;
+if there is a open cover $(U_\alpha)$ of $Y$, and, for every index $\alpha$, an $S$-morphism $v_\alpha:U_\alpha \to X$ such that, if $U_\alpha^0 = j^{-1}(U_\alpha)$, we have $v_\alpha \circ (j|U_\alpha^0) = u_0|U_\alpha^0$, then there is an $S$-morphism $u:Y \to X$ such that $u \circ j = u_0$.
+\end{corollary}
+
+\begin{proof}
+Indeed, $\sh{G}$ is a quasi-coherent $\sh{O}_{Y_0}$-module \sref[I]{I.1.3.12};
+by \sref{IV.16.5.16} and the fact that $Y_0$ is then affine, the sheaf $\sh{P}$, which is by hypothesis a torsor over $\sh{G}$, not only a pseudo-torsor, is \emph{trivial};
+but if $w$ is an isomorphism from $\sh{G}$ to $\sh{P}$ (as it is a torsor over $\sh{G}$), the image by $w$ of the zero section of $\sh{G}$ is the $S$-morphism we're looking for.
+\end{proof}

--- a/ega4/ega4-16.tex
+++ b/ega4/ega4-16.tex
@@ -1312,3 +1312,164 @@ If $f$ is locally of finite
 \oldpage[IV-4]{29}
 presentation, $\mathfrak{G}_{X/S}$ is a quasi-coherent $\sh{O}_X$-module; if also $S$ is locally Noetherian, $\mathfrak{G}_{X/S}$ is coherent \sref{IV.16.5.6}.
 \end{env}
+
+\begin{env}[16.5.8]
+\label{IV.16.5.8}
+Suppose in particular that $\Omega_{X/S}^1$ is a \emph{locally free} $\sh{O}_X$-module (of finite rank) (which will be the case then $f$ is smooth \sref{IV.17.2.3});
+then $\mathfrak{G}_{X/S}$ is locally free $\sh{O}_X$-module of same rank as $\Omega_{X/S}^1$ at each point.
+More specifically, suppose that $\Omega_{X/S}^1$ is of rank $n$ at a point $x$;
+then there are $n$ sections $s_i$ ($1 \leq i \leq n$) of $\sh{O}_X$ over an affine neighborhood $U$ of $x$ such that the canonical images of the $ds_i$ in $\Omega_{X/S}^1 \otimes \kres(x)$ form a basis if this $\kres(x)$-vector space;
+in virtue of Nakayama's lemma, the germs $(ds_i)_x = d(s_i)_x$ of the $ds_i$ at the point $x$ form a basis of the $\sh{O}_x$-module $(\Omega_{X/S}^1)_x$, and therefore, restricting $U$, we can suppose that the $ds_i$ form a \emph{basis} of the $\Gamma(U, \sh{O}_X)$-module $\Gamma(U, \Omega_{X/S}^1)$.
+So the $\Gamma(U, \sh{O}_X)$-module $\Gamma(U, \mathfrak{G}_{X/S})$ is dual to the above;
+and we denote $(D_i)_{1 \leq i \leq n}$ or $(\frac{\partial}{\partial s_i})_{1 \leq i \leq n}$ the dual basis of $(ds_i)_{1 \leq i \leq n}$, so that, by \sref{IV.16.5.3}, we have
+\[
+  \label{IV.16.5.8.1}
+  D_i s_j = \langle D_i, ds_j \rangle = \langle \frac{\partial}{\partial s_i}, ds_j \rangle = \delta_{ij} \quad \text{(Kronecker's symbol)}.
+  \tag{16.5.8.1}
+\]
+Every $\Gamma(S, \sh{O}_S)$-derivation of the $\Gamma(S, \sh{O}_S)$-algebra $\Gamma(U, \sh{O}_X)$ is written in an unique way as 
+\[
+  D = \sum_{i = 1}^n a_i D_i = \sum_{i = 1}^n a_i \frac{\partial}{\partial s_i}
+\] 
+where the $a_i$ ($1 \leq i \leq n$) are sections of $\sh{O}_X$ over $U$.
+For every section $g \in \Gamma(U, \sh{O}_X)$, if we put $dg = \sum_{i = 1}^n c_i ds_i$, we have $c_i = \langle D_i, dg \rangle = D_i g$ in virtue of \sref{IV.16.5.8.1}, in other words
+\[
+  \label{IV.16.5.8.2}
+  dg = \sum_{i = 1}^n (D_i g) ds_i = \sum_{i = 1}^n \frac{\partial g}{\partial s_i} ds_i.
+  \tag{16.5.8.2}
+\]
+\end{env}
+
+\begin{env}[16.5.9]
+\label{IV.16.5.9}
+Let $D_1$, $D_2$ be two $S$-derivations of $\sh{O}_X$. 
+For every open set $U$ of $X$, if $D_1^U$, $D_2^U$ are the corresponding derivations on the ring $\Gamma(U, \sh{O}_X)$, the \emph{bracket}
+\[
+  [D_1^U, D_2^U] = D_1^U \circ D_2^U - D_2^U \circ D_1^U
+\]
+is a derivation in this ring, and therefore the $\psi^*(\sh{O}_S)$-endomorphism of $\sh{O}_X$
+\[
+  \label{IV.16.5.9.1}
+  [D_1, D_2] = D_1 \circ D_2 - D_2 \circ D_1
+  \tag{16.5.9.1}
+\]
+is also an $S$-derivation;
+since one verifies immediately the Jacobi identity, we have thus defined on $\Der_S(\sh{O}_X, \sh{O}_X)$ a \emph{$\Gamma(S, \sh{O}_S)$-Lie algebra} structure.
+Since the definition of this structure commutes with the restriction to an open set of $X$, we thus see that $\mathfrak{G}_{X/S}$ is canonically endowed with a \emph{ $\psi^*(\sh{O}_S)$-Lie algebra} structure.
+Note that the mapping $(D_1, D_2) \mapsto [D_1, D_2]$ is \emph{not $\Gamma(X, \sh{O}_X)$-bilinear}.
+\end{env} 
+
+\begin{env}[16.5.10]
+\label{IV.16.5.10}
+For every base change $g:S' \to S$, putting $X' = X \times_S S'$, we see \sref{IV.16.4.5} that we have a canonical isomorphism
+\[
+  \label{IV.16.5.10.1}
+  \Omega_{X/S}^1 \otimes_S S' \xrightarrow{\sim} \Omega_{X'/S'}^1
+  \tag{16.5.10.1}
+\]
+\oldpage[IV-4]{30}  
+from where we deduce, by \sref{IV.16.5.10.1}, a canonical homomorphism (Bourbaki, \emph{Alg.}, chap.~II, 3rd ed. , \textsection5, no 3)
+\[
+  \label{IV.16.5.10.2}
+  \mathfrak{G}_{X/S} \otimes_{\sh{O}_S} \sh{O}_{S'} \to \mathfrak{G}_{X'/S'} 
+  \tag{16.5.10.2}
+\]
+which is neither injective nor surjective in general.
+However:
+\end{env}
+
+\begin{proposition}[16.5.11]
+\label{IV.16.5.11}
+\begin{enumerate}
+  \item[\rm{(i)}] If $g:S' \to S$ is a flat morphism and if $f$ is locally of finite type (resp. locally of finite presentation), the homomorphism \sref{IV.16.5.10.2} is injective (resp. bijective).
+  \item[\rm{(ii)}] If $\Omega_{X/S}^1$ is a locally free $\sh{O}_X$-module of finite rank, the homomorphism \sref{IV.16.5.10.2} is bijective.
+\end{enumerate}
+\end{proposition}
+
+\begin{proof}
+Indeed, the assertion \rm{(ii)} follows from Bourbaki, \emph{Alg.}, chap.~II, 3rd ed. , \textsection5, no 3, prop. 7.
+The assertion \rm(i) results similarly from Bourbaki, \emph{Alg. Comm.}, chap.~I, \textsection2, no 10, prop. 11 and of the fact that if $f$ is locally of finite type (resp. locally of finite presentation) $\Omega_{X/S}^1$ is a finite type (resp. finite presentation) $\sh{O}_X$-module \sref{IV.16.3.9} \sref{IV.16.4.22}. 
+\end{proof}
+
+\begin{env}[16.5.12]
+\label{IV.16.5.12}
+Since $\Omega_{X/S}^1$ is a quasi-coherent $\sh{O}_X$-module, we can consider the vector bundle over $X$ defined by $\Omega_{X/S}^1$ \sref[II]{II.1.7.8}
+\[
+  \label{IV.16.5.12.1}
+  T_{X/S} = \bb{V}(\Omega_{X/S}^1)
+  \tag{16.5.12.1}
+\]
+which is called the \emph{tangent bundle of $X$ relative to $S$}.
+We have therefore a canonical bijection \sref[II]{II.1.7.9}
+\[
+  \Gamma(T_{X/S}/S) \xrightarrow{\sim} \Hom_{\sh{O}_X}(\Omega_{X/S}^1, \sh{O}_X) = \Gamma(X, \mathfrak{G}_{X/S})
+\]
+by definition of $\mathfrak{G}_{X/S}$, and we can replace $X$ by an open set $U$ of $X$ in this isomorphism;
+so we can say that the \emph{tangent sheaf} of $X$ relative to $S$ is isomorphic to the \emph{sheaf of germs of $S$-sections} of the tangent bundle of $X$ relative to $S$.
+If $f:X \to Y$ is an $S$-morphism, we saw \sref{IV.16.4.19} that we have a canonical homomorphism $f_{X/Y/S}:f^*(\Omega_{Y/S}^1) \to \Omega_{X/S}^1$, which, having in mind that
+\[
+  \bb{V}(f^*(\Omega_{Y/S}^1)) = \bb{V}(\Omega_{Y/S}^1) \times_Y X \quad \text{\sref[II]{II.1.7.11} },
+\]
+gives us an $X$-morphism $T_{X/S}(f): T_{X/S} \to T_{Y/S} \times_Y X$.
+If $g:Y \to Z$ is a second $S$-morphism, we have $T_{X/S}(g \circ f) = (T_{Y/S}(g) \times 1_X ) \circ T_{X/S}(f)$ \sref[0]{0.20.5.4.1}.
+
+It results from \sref{IV.16.5.10.1} and from \sref[II]{II.1.7.11} that for every base change $g:S' \to S$ we have a canonical morphism
+\[
+  \label{IV.16.5.12.2}
+  T_{X'/S'} \xrightarrow{\sim} T_{X/S} \times_S S' = T_{X/S} \times_X X'.
+  \tag{16.5.12.2}
+\]
+\end{env}
+
+\begin{env}[16.5.13]
+\label{IV.16.5.13}
+For every point $x \in X$, we define the \emph{tangent space of $X$ at the point $x$} (relative to $S$) to be the set of points in the fiber $T_{X/S} \times_X \Spec(\kres(x))$ that are \emph{rational over $\kres(x)$}, that is the set
+\[
+  \label{IV.16.5.13.1}
+  T_{X/S}(x) = \Hom_{\kres(x)}(\Omega_{X/S}^1 \otimes_{\sh{O}_x} \kres(x), \kres(x))
+  \tag{16.5.13.1}
+\]
+which is the dual of the $\kres(x)$-vector space $\Omega_{\sh{O}_x/\sh{O}_s}^1/\mathfrak{m}_x.\Omega_{\sh{O}_x/\sh{O}_s}^1$.
+When $\Omega_{X/S}^1$ is a finite type $\sh{O}_X$-module, then $T_{X/S}$ is a vector space of finite rank over $\kres(x)$, and for every base change
+\oldpage[IV-4]{31}
+$g:S \to S'$, and every $x' \in X' = X \times_S S'$ over $x$, we have a canonical isomorphism
+\[
+  \label{IV.16.5.13.2}
+  T_{X'/S'}(x') \xrightarrow\sim T_{X/S} \otimes_{\kres(x)} \kres(x').
+  \tag{16.5.13.2}
+\]
+If $x$ is \emph{rational} over $\kres(s)$, where $s = f(x)$ (so that $\kres(s) \to \kres(x)$ is an isomorphism), it results from \sref{IV.16.4.13} that we have a canonical isomorphism
+\[
+  \label{IV.16.5.13.3}
+  T_{X/S}(x) = T_{X_s/\kres(s)}(x) = \Hom_{\kres(s)}(\mathfrak{m}'_x/\mathfrak{m}_x^{'2}, \kres(x))
+  \tag{16.5.13.3}
+\]
+where $\mathfrak{m}'_x$ is the maximal ideal of $\sh{O}_{X_s,x} = \sh{O}_{X, x}/\mathfrak{m}_s \sh{O}_{X,x}$.
+When $S$ is the spectrum of a field $k$, we recover the definition of Zariski tangent space of a point $x \in X$ \emph{rational over $k$} as the dual of $\mathfrak{m}_x / \mathfrak{m}_x^2$.
+
+Let $Y$ be a second $S$-prescheme and let $g:Y \to X$ be an $S$-morphism;
+then we have a canonical morphism of $\sh{O}_Y$-modules \sref{IV.16.4.19}
+\[
+  \label{IV.16.5.13.4}
+  g_{Y/X/S}: g^*(\Omega_{X/S}^1) \to \Omega_{Y/S}^1.
+  \tag{16.5.13.4}
+\]
+Now note that if $y \in Y$ and $x = g(y)$, we have
+\[
+  g^*(\Omega_{X/S}^1) \otimes_{\sh{O}_Y} \kres(y) = (\Omega_{X/S}^1 \otimes_{\sh{O}_X} \kres(x)) \otimes_{\sh{O}_Y} \kres(y) 
+\]
+and consequently, if $\Omega_{X/S}^1$ is a finite type $\sh{O}_X$-module, we can identify
+\[
+  \Hom_{\kres(y)}(g^*(\Omega_{X/S}^1) \otimes_{\sh{O}_Y} \kres(y), \kres(y))
+\]
+to $T_{X/S}(x) \otimes_{\kres(x)} \kres(y)$.
+We therefore deduce from the homomorphism \sref{IV.16.5.13.4} a homomorphism of $\kres(y)$-vector spaces
+\[
+  \label{IV.16.5.13.5}
+  T_y(g): T_{Y/S}(y) \to T_{X/S}(x) \otimes_{\kres(x)} \kres(y)
+  \tag{16.5.13.5}
+\]
+called the \emph{linear mapping tangent to $g$ at the point $y$}.
+When $y$ is \emph{rational over $\kres(s)$}, we can identify $\kres(s)$, $\kres(y)$ and $\kres(x)$, and $T_y(g)$ is then a homomorphism of $\kres(s)$-vector spaces $T_{Y/S} \to T_{X/S}(x)$;
+also note in this case, $g^*(\Omega_{X/S}^1) \otimes_{\sh{O}_Y} \kres(y)$ is identified with $\Omega_{X/S}^1 \otimes_{\sh{O}_X} \kres(x)$, and the above homomorphism is therefore defined without any conditions of finiteness on $\Omega_{X/S}^1$ and it is exactly the homomorphism \sref{IV.16.5.12} restricted to the fiber of $T_{Y/S}$ at $y$.
+\end{env}

--- a/ega4/ega4-16.tex
+++ b/ega4/ega4-16.tex
@@ -1239,7 +1239,7 @@ Then the mapping $D \mapsto \Gamma(D)$ which, to every $S$-derivation $D$ of $\s
 \end{proposition}
 
 \begin{proof}
-This results immediately from the given interpretation of $S$-derivations in terms
+This follows immediately from the given interpretation of $S$-derivations in terms
 \oldpage[IV-4]{28}
 of homomorphisms of algebras, analogous to the interpretation given in \sref[0]{0.20.1.6}, and of the canonical correspondence between homomorphisms of $\sh{O}_X$-algebras and homomorphisms of $B$-algebras ( \sref[I]{I.1.3.13} and  \sref[I]{I.1.3.8}).
 \end{proof}
@@ -1388,7 +1388,7 @@ However:
 
 \begin{proof}
 Indeed, the assertion \rm{(ii)} follows from Bourbaki, \emph{Alg.}, chap.~II, 3rd ed. , \textsection5, no 3, prop. 7.
-The assertion \rm(i) results similarly from Bourbaki, \emph{Alg. Comm.}, chap.~I, \textsection2, no 10, prop. 11 and of the fact that if $f$ is locally of finite type (resp. locally of finite presentation) $\Omega_{X/S}^1$ is a finite type (resp. finite presentation) $\sh{O}_X$-module \sref{IV.16.3.9} \sref{IV.16.4.22}. 
+The assertion \rm(i) follows similarly from Bourbaki, \emph{Alg. Comm.}, chap.~I, \textsection2, no 10, prop. 11 and of the fact that if $f$ is locally of finite type (resp. locally of finite presentation) $\Omega_{X/S}^1$ is a finite type (resp. finite presentation) $\sh{O}_X$-module \sref{IV.16.3.9} \sref{IV.16.4.22}. 
 \end{proof}
 
 \begin{env}[16.5.12]
@@ -1413,7 +1413,7 @@ If $f:X \to Y$ is an $S$-morphism, we saw \sref{IV.16.4.19} that we have a canon
 gives us an $X$-morphism $T_{X/S}(f): T_{X/S} \to T_{Y/S} \times_Y X$.
 If $g:Y \to Z$ is a second $S$-morphism, we have $T_{X/S}(g \circ f) = (T_{Y/S}(g) \times 1_X ) \circ T_{X/S}(f)$ \sref[0]{0.20.5.4.1}.
 
-It results from \sref{IV.16.5.10.1} and from \sref[II]{II.1.7.11} that for every base change $g:S' \to S$ we have a canonical morphism
+It follows from \sref{IV.16.5.10.1} and from \sref[II]{II.1.7.11} that for every base change $g:S' \to S$ we have a canonical morphism
 \[
   \label{IV.16.5.12.2}
   T_{X'/S'} \xrightarrow{\sim} T_{X/S} \times_S S' = T_{X/S} \times_X X'.
@@ -1438,7 +1438,7 @@ $g:S \to S'$, and every $x' \in X' = X \times_S S'$ over $x$, we have a canonica
   T_{X'/S'}(x') \xrightarrow\sim T_{X/S} \otimes_{\kres(x)} \kres(x').
   \tag{16.5.13.2}
 \]
-If $x$ is \emph{rational} over $\kres(s)$, where $s = f(x)$ (so that $\kres(s) \to \kres(x)$ is an isomorphism), it results from \sref{IV.16.4.13} that we have a canonical isomorphism
+If $x$ is \emph{rational} over $\kres(s)$, where $s = f(x)$ (so that $\kres(s) \to \kres(x)$ is an isomorphism), it follows from \sref{IV.16.4.13} that we have a canonical isomorphism
 \[
   \label{IV.16.5.13.3}
   T_{X/S}(x) = T_{X_s/\kres(s)}(x) = \Hom_{\kres(s)}(\mathfrak{m}'_x/\mathfrak{m}_x^{'2}, \kres(x))
@@ -1472,4 +1472,83 @@ We therefore deduce from the homomorphism \sref{IV.16.5.13.4} a homomorphism of 
 called the \emph{linear mapping tangent to $g$ at the point $y$}.
 When $y$ is \emph{rational over $\kres(s)$}, we can identify $\kres(s)$, $\kres(y)$ and $\kres(x)$, and $T_y(g)$ is then a homomorphism of $\kres(s)$-vector spaces $T_{Y/S} \to T_{X/S}(x)$;
 also note in this case, $g^*(\Omega_{X/S}^1) \otimes_{\sh{O}_Y} \kres(y)$ is identified with $\Omega_{X/S}^1 \otimes_{\sh{O}_X} \kres(x)$, and the above homomorphism is therefore defined without any conditions of finiteness on $\Omega_{X/S}^1$ and it is exactly the homomorphism \sref{IV.16.5.12} restricted to the fiber of $T_{Y/S}$ at $y$.
+\end{env}
+
+\begin{env}[16.5.14]
+\label{IV.16.5.14}
+The interpretation of derivations of an $A$-algebra $B$ to a $B$-module $L$, given in \sref[0]{0.20.1.1}, translates to the language of preschemes in the following way.
+
+Consider two morphisms of preschemes $f: X \to S$, $g: Y \to S$, and a closed subprescheme $Y_0$ of $Y$ defined by a \emph{zero-square} ideal $\sh{I}$ of $\sh{O}_Y$ (so that $Y$ and $Y_0$ have the same underlying subspace).
+Suppose we are given an $S$-morphism $u_0:Y_0 \to X$, so that we have a commutative diagram
+\[
+  \label{IV.16.5.14.1}
+  \xymatrix{
+    X \ar[d]_-f & Y_0 \ar[l]_-{u_0}\ar[d]^j \\
+    S & Y \ar@{-->}[ul]_-u \ar[l]^-g
+  }
+  \tag{16.5.14.1}
+\]
+\oldpage[IV-4]{32}
+and lets search for an \emph{$S$-morphism} $u:Y \to X$ such that $u_0 = u \circ j$ (in other words, if it is possible to complete the diagram above by the dotted arrow $u$ making it \emph{commutative}).
+
+For that, consider an affine open set $U = \Spec(C)$ of $Y$;
+its inverse image $j^{-1}(U)$ is the affine open $U_0 = \Spec(C/\mathfrak{L})$, where $\mathfrak{L} = \Gamma(U, \mathfrak{L})$, \emph{zero-square} ideal in $C$;
+suppose that $U$ is small enough so that $u_0(U_0)$ is contained in an affine open $V = \Spec(B)$ of $X$ and that $g(U) = f(u_0(U_0))$ is contained in an affine open $W = \Spec(A)$ of $S$, so that $B$ and $C$ are $A$-algebras and $u_0|U_0$ corresponds to an $A$-homomorphism $\psi$ from $B$ to $C/\mathfrak{L}$;
+Let $P(U_0)$ be the set of restrictions $u|U$ of the sought homomorphisms, which corresponds canonically to $A$-homomorphisms of algebras $\phi:B \to C$ such that the \emph{composite} $B \xrightarrow{\phi} C \to C/\mathfrak{L}$ is equal to $\psi$.
+So we know \sref[0]{0.20.1.1} that the set of such homomorphisms is either empty or of the form $\psi_1 + \Der_A(B, \mathfrak{L})$;
+since $P(U_0)$ is not empty, the additive group $\Der_A(B, \mathfrak{L})$ acts by addition on $P(U_0)$, which is therefore an \emph{affine space} for the additive group $\Der_A(B, \mathfrak{L})$ (or even a \emph{principal homogeneous space} (or \emph{torsor}) for $\Der_A(B, \mathfrak{L})$).
+
+Now notice that, since $\mathfrak{L}$ is endowed with a $B$-module structure via $\psi$, we have an isomorphism $v \mapsto v \circ d_{B/A}$ of $\Hom_B(\Omega_{X/S}^1, \mathfrak{L})$ onto $\Der_A(B, \mathfrak{L})$ \sref[0]{0.20.4.8}.
+Besides, as $\mathfrak{L}$ is square-zero, therefore a $(C/\mathfrak{L})$-module, every $B$-homomorphism $v: \Omega_{X/S}^1 \to \mathfrak{L}$ can be considered as a $(C/\mathfrak{L})$-homomorphism $\Omega_{X/S}^1 \otimes_B (C/\mathfrak{L}) \to \mathfrak{L}$.
+As $\sh{I}$ is square-zero, it can be considered as a quasi-coherent $\sh{O}_{Y_0}$-module;
+let's introduce the $\sh{O}_{Y_0}$-module
+\[
+  \label{IV.16.5.14.2}
+  \sh{G} = \shHom(u_0^*(\Omega_{X/S}^1), \sh{I});
+  \tag{16.5.14.2}
+\]
+it follows from the fact that $\Omega_{B/A}^1 = \Gamma(V, \Omega_{X/S}^1)$ \sref{IV.16.3.7} that we can write $\Der_A(B, \mathfrak{L}) = \Gamma(U_0, \sh{G})$.
+
+As $P(U_0)$ is defined as a set of $S$-morphisms $U \to X$, it is clear that $U_0 \mapsto P(U_0)$ is a \emph{sheaf of sets} $\sh{P}$ on $Y_0$.
+We can use this fact to prove that the mapping $h:\Gamma(U_0, \sh{G}) \times P(U_0) \to P(U_0)$ defining the torsor structure on $P(U_0)$ is independent of choice of $V$ and $W$ and also that, if $U' \subset U$ is a second affine open of $Y$, $U'_0$ the its inverse image in $Y_0$, the diagram
+\[
+  \label{IV.16.5.14.3}
+  \xymatrix{
+    \Gamma(U_0, \sh{G}) \times P(U_0) \ar[d] \ar[r]^-h & P(U_0) \ar[d] \\
+    \Gamma(U'_0, \sh{G}) \times P(U'_0) \ar[r]_-{h'} & P(U'_0)
+  }
+  \tag{16.5.14.3}
+\]
+is commutative (the vertical arrows being the restrictions).
+In light of the above remark, we are reduced to proving the commutativity of the above diagram when $h$ is defined as such from affine opens $V$, $W$ and $h'$ from affine
+\oldpage[IV-4]{33}
+opens $V' \subset V$ and $W' \subset W$.
+But in light of the preceding description of $h$, this results from the commutativity of the diagram \sref[0]{0.20.5.4.2}.
+
+The mapping $\Gamma(U_0, \sh{G}) \times P(U_0) \to P(U_0)$ therefore define a homomorphism of \emph{sheaf of sets} $m:\sh{G} \times \sh{P} \times \sh{P}$ such that, for all open sets $U_0$ for which $\Gamma(U_0, \sh{P}) \neq \emp$, $m_{U_0}:\Gamma(U_0, \sh{G}) \times \Gamma(U_0, \sh{P}) \to \Gamma(U_0, \sh{P})$ is an external law defining in $\Gamma(U_0, \sh{P})$ a torsor structure for the group $\Gamma(U_0, \sh{G})$.
+\end{env}
+
+\begin{env}[16.5.15]
+\label{IV.16.5.15}
+In general, when we are given a sheaf of sets $\sh{P}$ over a topological space $Z$, a sheaf of groups $\sh{G}$ (not necessarily commutative) and a homomorphism of sheaves of sets $m:\sh{G} \to \sh{P} \to \sh{P}$ such that, for every open $U \subset Z$ such that $\Gamma(U, \sh{P}) \neq \emp$, $m_U:\Gamma(U, \sh{G}) \times \Gamma(U, \sh{P}) \to \Gamma(U, \sh{P})$ makes $\Gamma(U, \sh{P})$ a \emph{torsor} for the group $\Gamma(U,\sh{G})$, we say that $\sh{P}$ is a \emph{pseudo-torsor} (or \emph{formally principal homogeneous sheaf}) for the sheaf of groups $\sh{G}$.
+We say that $\sh{P}$ is a \emph{torsor} (or \emph{principal homogeneous sheaf}) for $\sh{G}$
+\footnote{
+  [trans.] This is nowadays more commonly called a $\sh{G}$-torsor rather then a torsor \emph{over} $\sh{G}$.
+}
+if also $\Gamma(U, \sh{P}) \neq \emp$ for all open sets $U \neq \emp$ in a suitable basis for the topology of $Z$.
+
+For the general theory of torsors, we reference \cite{IV-42};
+we will limit ourselves to recalling the canonical correspondence between isomorphism classes of torsors (for \emph{given} $\sh{G}$) and elements from the cohomology $\HH^1(Z, \sh{G})$.
+Consider, indeed, a torsor $\sh{P}$ for $\sh{G}$ and a open cover $(U_\lambda)$ of $Z$ such that $\Gamma(U_\lambda, \sh{P}) \neq \emp$ for every $\lambda$;
+denote by $p_\lambda$ an element of $\Gamma(U_\lambda, \sh{P})$.
+For every pair of indexes $\lambda, \mu$ such that $U_\lambda \cap U_\mu \neq \emp$, there is one and only one element $\gamma_{\lambda\mu}$ of $\Gamma(U_\lambda \cap U_\mu, \sh{G})$ such that $\gamma_{\lambda\mu} . (p_\mu|U_\lambda \cap U_\mu) = p_\lambda|U_\lambda \cap U_\mu$;
+also, if $\lambda, \mu, \nu$ are three indexes such that $U_\lambda \cap U_\mu \cap U_\nu \neq \emp$, the restrictions $\gamma'_{\lambda\mu}$, $\gamma'_{\mu\nu}$, $\gamma'_{\lambda\nu}$ of $\gamma_{\lambda\mu}$, $\gamma_{\mu\nu}$, $\gamma_{\lambda\nu}$ to $U_\lambda \cap U_\mu \cap U_\nu$ verify the condition $\gamma'_{\lambda\nu} = \gamma'_{\lambda\mu}\gamma'_{\mu\nu}$;
+in other words, $(\lambda, \mu) \mapsto \gamma_{\lambda\mu}$ is a $1$-cocycle of the covering $(U_\lambda)$ with values in $\sh{G}$.
+If, for every $\lambda$, $p'_\lambda$ is a second element of $\Gamma(U_\lambda, \sh{P})$, it exists one and only one element $\beta_\lambda \in \Gamma(U_\lambda, \sh{G})$ such that $p'_\lambda = \beta_\lambda . p_\lambda$, and the $1$-cocycle $(\gamma'_{\lambda\mu})$ corresponding to the family $(p'_\lambda)$ is given by $\gamma'_{\lambda\mu} = \beta_\lambda \gamma_{\lambda\mu} \beta_\mu^{-1}$, that is, it is \emph{cohomologous} to $\gamma_{\lambda\mu}$.
+On the other hand, the data of a $1$-cocycle $(\gamma_{\lambda\mu})$ defines, for every pair $(\lambda, \mu)$, an automorphism $\theta_{\lambda\mu}$ of the sheaf \emph{of sets} $\sh{G}|U_\lambda \cap U_\mu$, namely the right translation by $\gamma_{\lambda\mu}$, and the fact that it is a cocycle shows that we can \emph{glue} the sheaves of sets $\sh{G}|U_\lambda$ via the automorphisms $\theta_{\lambda\mu}$ \sref[0]{0.3.3.1};
+we obtain as such a torsor over $\sh{G}$, call it $\sh{P}$, and if we take for $p_\lambda$ the unit section over $U_\lambda$, the corresponding $1$-cocycle is exactly the given $1$-cocycle $(\gamma_{\lambda\mu})$;
+also, if we replace $(\gamma_{\lambda\mu})$ by an $1$-cocycle $\gamma'_{\lambda\mu} = \beta_\lambda \gamma_{\lambda\mu} \beta_\mu^{-1}$ cohomologous to it we verify immediately that the torsor obtained is isomorphic to $\sh{P}$.
+
+In particular,if $(\gamma_{\lambda\mu})$ is a $1$-coboundary, in other words of the form $\gamma_{\lambda\mu} = \beta_\lambda\beta_\mu^{-1}$, the obtained torsor $\sh{P}$ is \emph{isomorphic} to $\sh{G}$ (considered as a torsor over itself by left translations);
+we say in this case that $\sh{P}$ is trivial, and the converse is obvious.
 \end{env}

--- a/ega4/ega4-16.tex
+++ b/ega4/ega4-16.tex
@@ -1270,12 +1270,12 @@ also, the uniqueness of the $u_V$ shows immediately that for an affine open $W \
 \label{IV.16.5.4}
 With the notations of \sref{IV.16.5.1}, for every open set $U$ of $X$, $\Der_S(\sh{O}_U, \sh{F}|U)$ is a $\Gamma(U, \sh{O}_X)$-module and it is cleat that the application $U \mapsto \Der_S(\sh{O}_U, \sh{F}|U)$ is a presheaf;
 in fact, it is even a \emph{sheaf} (and therefore an $\sh{O}_X$-module), in light of the pointwise characterization of $S$-derivations, seen in \sref{IV.16.5.1}.
-This $\sh{O}_X$-module is denoted by $\shDer_S(\sh{O}_X, \sh{F})$ and is called the \emph{sheaf of $S$-derivations of $\sh{O}_X$ in $\sh{F}$}, and what we've come to see is further expressed in the following corollary:
+This $\sh{O}_X$-module is denoted by $\shDer_S(\sh{O}_X, \sh{F})$ and is called the \emph{sheaf of $S$-derivations of $\sh{O}_X$ in $\sh{F}$}, and what we have seen is further expressed in the following corollary:
 \end{env}
 
 \begin{corollary}[16.5.5]
 \label{IV.16.5.5}
-For every $\sh{O}_X$-module $\sh{F}$, the homomorphism of $\sh{O}_X$-modules deduced from $d\mapsto u \circ d_{X/S}$
+For every $\sh{O}_X$-module $\sh{F}$, the homomorphism of $\sh{O}_X$-modules deduced from $u \mapsto u \circ d_{X/S}$
 \[
   \label{IV.16.5.5.1}
   \shHom_{\sh{O}_X}(\Omega_{X/S}^1, \sh{F}) \to \shDer_S(\sh{O}_X, \sh{F})
@@ -1300,14 +1300,14 @@ the assertion (ii) follows from \sref[0]{0.5.3.5}.
 
 \begin{env}[16.5.7]
 \label{IV.16.5.7}
-We put
+Let
 \[
   \label{IV.16.5.7.1}
   \mathfrak{G}_{X/S} = \shHom_{\sh{O}_X}(\Omega_{X/S}^1, \sh{O}_X) = \shDer_S(\sh{O}_X, \sh{O}_X)
   \tag{16.5.7.1}  
 \]
 and say that it is the \emph{sheaf of $S$-derivations of $\sh{O}_X$}, or even the \emph{tangent sheaf of $X$ relative to $S$}:
-it is therefore the dual of the $\sh{O}_X$-module $\Omega_{X/S}^1$.
+it is therefore the \emph{dual} of the $\sh{O}_X$-module $\Omega_{X/S}^1$.
 If $f$ is locally of finite
 \oldpage[IV-4]{29}
 presentation, $\mathfrak{G}_{X/S}$ is a quasi-coherent $\sh{O}_X$-module; if also $S$ is locally Noetherian, $\mathfrak{G}_{X/S}$ is coherent \sref{IV.16.5.6}.
@@ -1413,7 +1413,7 @@ If $f:X \to Y$ is an $S$-morphism, we saw \sref{IV.16.4.19} that we have a canon
 gives us an $X$-morphism $T_{X/S}(f): T_{X/S} \to T_{Y/S} \times_Y X$.
 If $g:Y \to Z$ is a second $S$-morphism, we have $T_{X/S}(g \circ f) = (T_{Y/S}(g) \times 1_X ) \circ T_{X/S}(f)$ \sref[0]{0.20.5.4.1}.
 
-It follows from \sref{IV.16.5.10.1} and from \sref[II]{II.1.7.11} that for every base change $g:S' \to S$ we have a canonical morphism
+It follows from \sref{IV.16.5.10.1} and from \sref[II]{II.1.7.11} that for every base change $g:S' \to S$ we have a canonical isomorphism
 \[
   \label{IV.16.5.12.2}
   T_{X'/S'} \xrightarrow{\sim} T_{X/S} \times_S S' = T_{X/S} \times_X X'.
@@ -1423,14 +1423,14 @@ It follows from \sref{IV.16.5.10.1} and from \sref[II]{II.1.7.11} that for every
 
 \begin{env}[16.5.13]
 \label{IV.16.5.13}
-For every point $x \in X$, we define the \emph{tangent space of $X$ at the point $x$} (relative to $S$) to be the set of points in the fiber $T_{X/S} \times_X \Spec(\kres(x))$ that are \emph{rational over $\kres(x)$}, that is the set
+For every point $x \in X$, we define the \emph{tangent space of $X$ at the point $x$} (relative to $S$) to be the set of points in the fiber $T_{X/S} \times_X \Spec(\kres(x))$ that are \emph{rational over $\kres(x)$}, that is, the set
 \[
   \label{IV.16.5.13.1}
   T_{X/S}(x) = \Hom_{\kres(x)}(\Omega_{X/S}^1 \otimes_{\sh{O}_x} \kres(x), \kres(x))
   \tag{16.5.13.1}
 \]
 which is the dual of the $\kres(x)$-vector space $\Omega_{\sh{O}_x/\sh{O}_s}^1/\mathfrak{m}_x.\Omega_{\sh{O}_x/\sh{O}_s}^1$.
-When $\Omega_{X/S}^1$ is a finite type $\sh{O}_X$-module, then $T_{X/S}$ is a vector space of finite rank over $\kres(x)$, and for every base change
+When $\Omega_{X/S}^1$ is a finite type $\sh{O}_X$-module, then $T_{X/S}(x)$ is a vector space of finite rank over $\kres(x)$, and for every base change
 \oldpage[IV-4]{31}
 $g:S \to S'$, and every $x' \in X' = X \times_S S'$ over $x$, we have a canonical isomorphism
 \[
@@ -1470,8 +1470,8 @@ We therefore deduce from the homomorphism \sref{IV.16.5.13.4} a homomorphism of 
   \tag{16.5.13.5}
 \]
 called the \emph{linear mapping tangent to $g$ at the point $y$}.
-When $y$ is \emph{rational over $\kres(s)$}, we can identify $\kres(s)$, $\kres(y)$ and $\kres(x)$, and $T_y(g)$ is then a homomorphism of $\kres(s)$-vector spaces $T_{Y/S} \to T_{X/S}(x)$;
-also note in this case, $g^*(\Omega_{X/S}^1) \otimes_{\sh{O}_Y} \kres(y)$ is identified with $\Omega_{X/S}^1 \otimes_{\sh{O}_X} \kres(x)$, and the above homomorphism is therefore defined without any conditions of finiteness on $\Omega_{X/S}^1$ and it is exactly the homomorphism \sref{IV.16.5.12} restricted to the fiber of $T_{Y/S}$ at $y$.
+When $y$ is \emph{rational over $\kres(s)$}, we can identify $\kres(s)$, $\kres(y)$ and $\kres(x)$, and $T_y(g)$ is then a homomorphism of $\kres(s)$-vector spaces $T_{Y/S}(y) \to T_{X/S}(x)$;
+also note in this case, $g^*(\Omega_{X/S}^1) \otimes_{\sh{O}_Y} \kres(y)$ is identified with $\Omega_{X/S}^1 \otimes_{\sh{O}_X} \kres(x)$, and the above homomorphism is therefore defined without any conditions of finiteness on $\Omega_{X/S}^1$ and it is exactly the homomorphism $T_{Y/S}(g)$\sref{IV.16.5.12} restricted to the fiber of $T_{Y/S}$ at $y$.
 \end{env}
 
 \begin{env}[16.5.14]
@@ -1489,14 +1489,14 @@ Suppose we are given an $S$-morphism $u_0:Y_0 \to X$, so that we have a commutat
   \tag{16.5.14.1}
 \]
 \oldpage[IV-4]{32}
-and lets search for an \emph{$S$-morphism} $u:Y \to X$ such that $u_0 = u \circ j$ (in other words, if it is possible to complete the diagram above by the dotted arrow $u$ making it \emph{commutative}).
+and lets search for an \emph{$S$-morphism} $u:Y \to X$ such that $u_0 = u \circ j$ (in other words, completing the diagram above by the dotted arrow $u$ making it \emph{commutative}).
 
 For that, consider an affine open set $U = \Spec(C)$ of $Y$;
 its inverse image $j^{-1}(U)$ is the affine open $U_0 = \Spec(C/\mathfrak{L})$, where $\mathfrak{L} = \Gamma(U, \mathfrak{L})$, \emph{zero-square} ideal in $C$;
 suppose that $U$ is small enough so that $u_0(U_0)$ is contained in an affine open $V = \Spec(B)$ of $X$ and that $g(U) = f(u_0(U_0))$ is contained in an affine open $W = \Spec(A)$ of $S$, so that $B$ and $C$ are $A$-algebras and $u_0|U_0$ corresponds to an $A$-homomorphism $\psi$ from $B$ to $C/\mathfrak{L}$;
 Let $P(U_0)$ be the set of restrictions $u|U$ of the sought homomorphisms, which corresponds canonically to $A$-homomorphisms of algebras $\phi:B \to C$ such that the \emph{composite} $B \xrightarrow{\phi} C \to C/\mathfrak{L}$ is equal to $\psi$.
 So we know \sref[0]{0.20.1.1} that the set of such homomorphisms is either empty or of the form $\psi_1 + \Der_A(B, \mathfrak{L})$;
-since $P(U_0)$ is not empty, the additive group $\Der_A(B, \mathfrak{L})$ acts by addition on $P(U_0)$, which is therefore an \emph{affine space} for the additive group $\Der_A(B, \mathfrak{L})$ (or even a \emph{principal homogeneous space} (or \emph{torsor}) for $\Der_A(B, \mathfrak{L})$).
+when $P(U_0)$ is not empty, the additive group $\Der_A(B, \mathfrak{L})$ acts by addition on $P(U_0)$, which is therefore an \emph{affine space} for the additive group $\Der_A(B, \mathfrak{L})$ (or even a \emph{principal homogeneous space} (or \emph{torsor}) for $\Der_A(B, \mathfrak{L})$).
 
 Now notice that, since $\mathfrak{L}$ is endowed with a $B$-module structure via $\psi$, we have an isomorphism $v \mapsto v \circ d_{B/A}$ of $\Hom_B(\Omega_{X/S}^1, \mathfrak{L})$ onto $\Der_A(B, \mathfrak{L})$ \sref[0]{0.20.4.8}.
 Besides, as $\mathfrak{L}$ is square-zero, therefore a $(C/\mathfrak{L})$-module, every $B$-homomorphism $v: \Omega_{X/S}^1 \to \mathfrak{L}$ can be considered as a $(C/\mathfrak{L})$-homomorphism $\Omega_{X/S}^1 \otimes_B (C/\mathfrak{L}) \to \mathfrak{L}$.
@@ -1523,7 +1523,7 @@ is commutative (the vertical arrows being the restrictions).
 In light of the above remark, we are reduced to proving the commutativity of the above diagram when $h$ is defined as such from affine opens $V$, $W$ and $h'$ from affine
 \oldpage[IV-4]{33}
 opens $V' \subset V$ and $W' \subset W$.
-But in light of the preceding description of $h$, this results from the commutativity of the diagram \sref[0]{0.20.5.4.2}.
+But because of the preceding description of $h$, this results from the commutativity of the diagram \sref[0]{0.20.5.4.2}.
 
 The mapping $\Gamma(U_0, \sh{G}) \times P(U_0) \to P(U_0)$ therefore define a homomorphism of \emph{sheaf of sets} $m:\sh{G} \times \sh{P} \times \sh{P}$ such that, for all open sets $U_0$ for which $\Gamma(U_0, \sh{P}) \neq \emp$, $m_{U_0}:\Gamma(U_0, \sh{G}) \times \Gamma(U_0, \sh{P}) \to \Gamma(U_0, \sh{P})$ is an external law defining in $\Gamma(U_0, \sh{P})$ a torsor structure for the group $\Gamma(U_0, \sh{G})$.
 \end{env}

--- a/ega4/ega4-16.tex
+++ b/ega4/ega4-16.tex
@@ -1196,3 +1196,116 @@ One generalizes immediately \sref{IV.16.4.23} to the case of a product of any fi
   It also seems that, for various kinds of ``varieties'', the ``global'' constructions of the $\sh{P}^n$ analogous to those we've used here are also better suited for applications.
 \end{enumerate}
 \end{remarks}
+
+\subsection{Relative tangent sheaves and bundles; derivations.}
+\label{IV.16.5}
+
+\begin{env}[16.5.1]
+\label{IV.16.5.1}
+Let $f = (\psi, \theta):X \to S$ be a morphism of ringed spaces.
+For every $\sh{O}_X$-module $\sh{F}$, we call $S$-\emph{derivation} (or $(X/S)$-derivation, or $f$-derivation) of $\sh{O}_X$ in $\sh{F}$ every homomorphism of \emph{sheaves of additive groups} $D: \sh{O}_X \to \sh{F}$, verifying the following conditions:
+\begin{enumerate}
+  \item[a)] for every open set $V$ of $X$, and all pair of sections $(t_1, t_2)$ of $\sh{O}_X$ over $V$, we have
+  \[
+    \label{IV.16.5.1.1}
+    D(t_1t_2) = t_1D(t_2) + D(t_1)t_2;
+    \tag{16.5.1.1}
+  \]
+  \item[b)] for every open set $V$ of $X$, every section $t$ of $\sh{O}_X$ over $V$ and every section $s$ of $\sh{O}_S$ over an open set $U$ of $S$ such that $V \subset f^{-1}(U)$, we have
+  \[
+    \label{IV.16.5.1.2}
+    D((s|V)t) = (s|V)D(t).
+    \tag{16.5.1.2}
+  \]
+\end{enumerate}
+It is clear that this amounts to saying that, for all $x \in X$, the homomorphism of additive groups $D_x:\sh{O}_X \to \sh{F}_x$ is an $\sh{O}_{f(x)}$-derivation.
+
+Another interpretation consists in considering the $\sh{O}_X$-algebra $\sh{D}_{\sh{O}_X}(\sh{F})$ equal to $\sh{O}_X \oplus \sh{F}$, the algebra structure being defined by the condition that for every open set $V$ of $X$, the product of two section of $\sh{O}_X$ (resp. of a section of $\sh{O}_X$ and a section of $\sh{F}$) over $V$ is defined by the ring structure of $\Gamma(V, \sh{O}_X)$ (resp. the structure of $\Gamma(V, \sh{O}_X)$-module of $\Gamma(V, \sh{F})$), and the product of two sections of $\sh{F}$ over $V$ is chosen to be zero;
+then $\sh{F}$ is an ideal of $\sh{D}_{\sh{O}_X}(\sh{F})$, kernel of the canonical augmentation $\sh{D}_{\sh{O}_X}(\sh{F}) \to \sh{O}_X$, and to say that $D$ is an $S$-derivation of $\sh{O}_X$ in $\sh{F}$ means that $I_{\sh{O}_X} + D$ is an $\sh{O}_S$-homomorphism of algebras from $\sh{O}_X$ into $\sh{D}_{\sh{O}_X}(\sh{F})$, which, composed with the augmentation, gives $1_{\sh{O}_X}$.
+
+The $S$-derivations of $\sh{O}_X$ in $\sh{F}$ clearly form a $\Gamma(X, \sh{O}_X)$-module $\Der_{\sh{O}_S}(\sh{O}_X, \sh{F})$.
+
+When $\sh{F} = \sh{O}_X$, an $S$-derivation of $\sh{O}_X$ into itself is simply called an $S$-derivation of $\sh{O}_X$.
+\end{env}
+
+\begin{proposition}[16.5.2]
+\label{IV.16.5.2}
+Let $A$ be a ring, $B$ an $A$-algebra, $L$ a $B$-module;
+let $S = \Spec(A)$, $X=\Spec(B)$, $\sh{F} = \widetilde{L}$.
+Then the mapping $D \rightsquigarrow \Gamma(D)$ which, to every $S$-derivation $D$ of $\sh{O}_X$ in $\sh{F}$ gives us the mapping $\Gamma(D): t \rightsquigarrow D(t)$ of $B$ in $L$, is an isomorphism of $B$-modules of $\Der_S(\sh{O}_X, \sh{F})$ onto $\Der_A(B, L)$ (cf. \sref[0]{0.20.1.2}).
+\end{proposition}
+
+\begin{proof}
+This results immediately from the given interpretation of $S$-derivations in terms
+\oldpage[IV-4]{28}
+of homomorphisms of algebras, analogous to the interpretation given in \sref[0]{0.20.1.6}, and of the canonical correspondence between homomorphisms of $\sh{O}_X$-algebras and homomorphisms of $B$-algebras ( \sref[I]{I.1.3.13} and  \sref[I]{I.1.3.8}).
+\end{proof}
+
+\begin{proposition}[16.5.3]
+\label{IV.16.5.3}
+Let $f = (\psi, \theta): X \to S$ be a morphism of preschemes.
+\begin{enumerate}
+  \item[(i)] The differential $d_{X/S}:\sh{O}_X \to \Omega_{X/S}^1$ \sref{IV.16.3.6} is an $S$-derivation.
+  \item[(ii)] For every $\sh{O}_X$-module $\sh{F}$, the mapping $u \rightsquigarrow u \circ d_{X/S}$ is an isomorphism of $\Gamma(X, \sh{O}_X)$-modules
+  \[
+    \label{IV.16.5.3.1}
+    \Hom_{\sh{O}_X}(\Omega_{X/S}^1, \sh{F}) \xrightarrow\sim \Der_S(\sh{O}_X, \sh{F}).
+    \tag{16.5.3.1}
+  \]
+\end{enumerate}
+\end{proposition}
+
+\begin{proof}
+The assertion (i) has already been noted \sref{IV.16.3.6}.
+On the other hand, it is immediate (in light of \sref[0]{0.20.4.8}) that $u \rightsquigarrow u\circ d_{X/S}$ is injective, considering considering the restrictions to a fiber $\sh{O}_x$ of the two members and \sref{IV.16.4.16.2}.
+To see that the homomorphism \sref{IV.16.5.3.1} is surjective, consider an $S$-derivation $D: \sh{O}_X \to \sh{F}$;
+for every affine open $V = \Spec(B) $ of $X$, such that $f(V)$ is contained in  an affine open $U = \Spec (A)$ of $S$, $D_V:B \to \Gamma(V, \sh{F}) $ is an $A$-derivation, and therefore there exists a \emph{unique} $B$-homomorphism $u_V:\Omega_{B/A}^1 \to \Gamma(V, \sh{F})$ such that $D_V = u_V \circ d_{B/A}$ \sref[0]{0.20.4.8};
+also, the uniqueness of the $u_V$ shows immediately that for an affine open $W \subset V$ we have $u_W = u_V|W$, and therefore the $u_V$ define a homomorphism of $\sh{O}_X$-modules $u:\sh{O}_X \to \sh{F}$ answering the question.
+\end{proof}
+
+\begin{env}[16.5.4]
+\label{IV.16.5.4}
+With the notations of \sref{IV.16.5.1}, for every open set $U$ of $X$, $\Der_S(\sh{O}_U, \sh{F}|U)$ is a $\Gamma(U, \sh{O}_X)$-module and it is cleat that the application $U \rightsquigarrow \Der_S(\sh{O}_U, \sh{F}|U)$ is a presheaf;
+in fact, it is even a \emph{sheaf} (and therefore an $\sh{O}_X$-module), in light of the pointwise characterization of $S$-derivations, seen in \sref{IV.16.5.1}.
+This $\sh{O}_X$-module is denoted by $\shDer_S(\sh{O}_X, \sh{F})$ and is called the \emph{sheaf of $S$-derivations of $\sh{O}_X$ in $\sh{F}$}, and what we've come to see is further expressed in the following corollary:
+\end{env}
+
+\begin{corollary}[16.5.5]
+\label{IV.16.5.5}
+For every $\sh{O}_X$-module $\sh{F}$, the homomorphism of $\sh{O}_X$-modules deduced from $d\rightsquigarrow u \circ d_{X/S}$
+\[
+  \label{IV.16.5.5.1}
+  \shHom_{\sh{O}_X}(\Omega_{X/S}^1, \sh{F}) \to \shDer_S(\sh{O}_X, \sh{F})
+  \tag{16.5.5.1}
+\]
+is bijective.
+\end{corollary}
+
+
+\begin{corollary}[16.5.6]
+\label{IV.16.5.6}
+\begin{enumerate}
+  \item[(i)] If the morphism $f:X \to S$ is locally of finite presentation and if $\sh{F}$ is a quasi-coherent $\sh{O}_X$-module, then $\shDer_S(\sh{O}_X, \sh{F})$ is a quasi-coherent $\sh{O}_X$-module.
+  \item[(ii)] If $S$ is also locally Noetherian and if $\sh{F}$ is quasi-coherent, then $\shDer_S(\sh{O}_X, \sh{F})$ is a coherent $\sh{O}_X$-module.
+\end{enumerate}
+\end{corollary}
+
+\begin{proof}
+The assertion (i) follows from the isomorphism \sref{IV.16.5.5.1}, from \sref{IV.16.4.22} and \sref[I]{I.3.12};
+the assertion (ii) follows from \sref[0]{0.5.3.5}.
+\end{proof}
+
+\begin{env}[16.5.7]
+\label{IV.16.5.7}
+We put
+\[
+  \label{IV.16.5.7.1}
+  \mathfrak{G}_{X/S} = \shHom_{\sh{O}_X}(\Omega_{X/S}^1, \sh{O}_X) = \shDer_S(\sh{O}_X, \sh{O}_X)
+  \tag{16.5.7.1}  
+\]
+and say that it is the \emph{sheaf of $S$-derivations of $\sh{O}_X$}, or even the \emph{tangent sheaf of $X$ relative to $S$}:
+it is therefore the dual of the $\sh{O}_X$-module $\Omega_{X/S}^1$.
+If $f$ is locally of finite
+\oldpage[IV-4]{29}
+presentation, $\mathfrak{G}_{X/S}$ is a quasi-coherent $\sh{O}_X$-module; if also $S$ is locally Noetherian, $\mathfrak{G}_{X/S}$ is coherent \sref{IV.16.5.6}.
+\end{env}

--- a/preamble-base.tex
+++ b/preamble-base.tex
@@ -36,6 +36,7 @@
 \def\dimc{\operatorname{dimc}}
 \def\codim{\operatorname{codim}}
 \def\id{\operatorname{id}}
+\def\Der{\operatorname{Der}}
 
 \renewcommand{\to}{\mathchoice{\longrightarrow}{\rightarrow}{\rightarrow}{\rightarrow}}
 \newcommand{\from}{\mathchoice{\longleftarrow}{\leftarrow}{\leftarrow}{\leftarrow}}

--- a/preamble.tex
+++ b/preamble.tex
@@ -87,6 +87,7 @@
 \def\shProj{\sh{P}\textup{\kern-2.2pt{\Fontauri\slshape roj}}} % sheaf Proj
 \def\shExt{\sh{E}\textup{\kern-2.2pt{\Fontauri\slshape xt}}}   % sheaf Ext
 \def\shGr{\sh{G}\textup{\kern-2.2pt{\Fontauri\slshape r}}}     % sheaf Gr
+\def\shDer{\sh{D}\,\textup{\kern-2.2pt{\Fontauri\slshape er}}}   % sheaf Der
 
 % if unsure of a translation
 %\newcommand{\unsure}[2][]{\hl{#2}\marginpar{#1}}


### PR DESCRIPTION
Also created an operator for the space of derivations and its associated sheaf (which will eventually be also necessary on section 0.20).

They call "$G$-torseur" by the name of "torseur sous $G$", which seems to have an english equivalent as "torsor over $G$". 
Anyway, it seemed more closer to the spirit of this project to leave it as "torsor over $G$" even though the first term seems
standard nowadays since we're calling "schemes" "preschemes".
